### PR TITLE
Driver timeout

### DIFF
--- a/driver/vck5000.c
+++ b/driver/vck5000.c
@@ -137,11 +137,18 @@ static void vck5000_send_admin_queue_cmd_and_wait(struct amdair_device *air_dev,
 			   + pkt_id * AQL_PKT_SIZE
 			   + AQL_PKT_COMPLETION_SIGNAL_OFFSET);
 
+  uint64_t timeout_count = 0;
 	while (completion_signal_val) {
 		completion_signal_val
 			= ioread64(air_dev->queue_mgr.admin_queue.ring_buf
 				   + pkt_id * AQL_PKT_SIZE
 			   	   + AQL_PKT_COMPLETION_SIGNAL_OFFSET);
+
+    if(timeout_count >= KERNEL_CMD_TIMEOUT_VAL) {
+      dev_warn(&air_dev->pdev->dev, "Timed out on kernel command. Firmware most likely needs to be reset.");
+      break;
+    }
+    timeout_count++;
 	}
 
 	if (cmd_type == AQL_AIR_PKT_TYPE_READ_AIE_REG32) {

--- a/driver/vck5000.c
+++ b/driver/vck5000.c
@@ -137,18 +137,18 @@ static void vck5000_send_admin_queue_cmd_and_wait(struct amdair_device *air_dev,
 			   + pkt_id * AQL_PKT_SIZE
 			   + AQL_PKT_COMPLETION_SIGNAL_OFFSET);
 
-  uint64_t timeout_count = 0;
+ 	uint64_t timeout_count = 0;
 	while (completion_signal_val) {
 		completion_signal_val
 			= ioread64(air_dev->queue_mgr.admin_queue.ring_buf
 				   + pkt_id * AQL_PKT_SIZE
 			   	   + AQL_PKT_COMPLETION_SIGNAL_OFFSET);
 
-    if(timeout_count >= KERNEL_CMD_TIMEOUT_VAL) {
-      dev_warn(&air_dev->pdev->dev, "Timed out on kernel command. Firmware most likely needs to be reset.");
-      break;
-    }
-    timeout_count++;
+    		if(timeout_count >= KERNEL_CMD_TIMEOUT_VAL) {
+    			dev_warn(&air_dev->pdev->dev, "Timed out on kernel command. Firmware most likely needs to be reset.");
+    			break;
+    		}
+    		timeout_count++;
 	}
 
 	if (cmd_type == AQL_AIR_PKT_TYPE_READ_AIE_REG32) {

--- a/driver/vck5000.h
+++ b/driver/vck5000.h
@@ -10,6 +10,12 @@
 #define VCK5000_AIE_MEM_RANGE 0x20000000
 
 /**
+ * When the kernel will timeout after sending
+ * a command
+ */
+#define KERNEL_CMD_TIMEOUT_VAL 10000
+
+/**
  * vck5000_dev_init - Initialize a VCK5000 device.
  */
 void vck5000_dev_init(struct amdair_device *air_dev);


### PR DESCRIPTION
Adding a timeout in the driver when we send a kernel packet so we don't hang when the firmware is unresponsive. 