### PR TITLE
Queue release

### DIFF
--- a/driver/amdair_process.h
+++ b/driver/amdair_process.h
@@ -44,6 +44,8 @@ struct amdair_process_device {
 
 	uint32_t db_page_id;
 	int num_dbs;
+	
+	uint32_t queue_id[MAX_HW_QUEUES];
 	DECLARE_BITMAP(doorbell_id_map, DOORBELLS_PER_PROCESS);
 
 	struct rb_root_cached dram_heap;
@@ -90,6 +92,8 @@ int amdair_process_get_process_device(struct amdair_process *air_process,
 
 int amdair_process_assign_doorbell(struct amdair_process *air_process,
 				   uint32_t dev_id, uint32_t *db_id);
+int amdair_process_assign_queue(struct amdair_process *air_process,
+				   uint32_t dev_id, uint32_t *queue_id);
 int amdair_process_doorbell_release(struct amdair_process *air_process,
 				    uint32_t dev_id, uint32_t db_id);
 #endif /* AMDAIR_PROCESS_H_ */

--- a/driver/amdair_queue.c
+++ b/driver/amdair_queue.c
@@ -3,6 +3,7 @@
 
 #include "amdair_queue.h"
 #include "amdair_device.h"
+#include "amdair_process.h"
 
 int amdair_queue_find_free(struct amdair_device *air_dev)
 {
@@ -14,11 +15,32 @@ int amdair_queue_find_free(struct amdair_device *air_dev)
 	return queue_id;
 }
 
-int amdair_queue_release(struct amdair_device *air_dev, uint32_t queue_id)
+int amdair_queue_release(struct amdair_process *air_process, uint32_t queue_id)
 {
+	int i = 0, q = 0;
+	struct amdair_device *air_dev = NULL;
+
+	// Searching for the amdair_process_device that is using this
+	// queue so we can mark that it will be removed. While we are 
+	// at it can get a pointer to the device as well
+	for (i = 0; i < air_process->num_proc_devs; i++) {
+		for (q = 0; q < MAX_HW_QUEUES; q++) {
+			if(queue_id == air_process->proc_devs[i].queue_id[q]) {
+				air_process->proc_devs[i].queue_id[q] = QUEUE_INVALID_ID;
+				air_dev = air_process->proc_devs[i].dev;
+				break;
+			}
+		}
+	}
+
+	if(air_dev == NULL) {
+		return -EINVAL;
+	}
+
 	if (queue_id >= air_dev->queue_mgr.num_hw_queues) {
 		return -EINVAL;
 	}
+
 
 	clear_bit(queue_id, air_dev->queue_mgr.hw_queue_map);
 

--- a/driver/amdair_queue.h
+++ b/driver/amdair_queue.h
@@ -10,6 +10,7 @@
 #define QUEUE_INVALID_ID	0xFFFFFFFFU
 
 struct amdair_device;
+struct amdair_process;
 
 /**
  * struct amdair_admin_queue - Command queue managed by the kernel to send
@@ -66,6 +67,6 @@ struct amdair_queue_manager {
 };
 
 int amdair_queue_find_free(struct amdair_device *air_dev);
-int amdair_queue_release(struct amdair_device *air_dev, uint32_t queue_id);
+int amdair_queue_release(struct amdair_process *air_process, uint32_t queue_id);
 
 #endif /* AMDAIR_QUEUE_H_ */

--- a/driver/vck5000.c
+++ b/driver/vck5000.c
@@ -107,6 +107,7 @@ static void vck5000_send_admin_queue_cmd_and_wait(struct amdair_device *air_dev,
 	int pkt_id = wr_idx % air_dev->queue_mgr.queue_num_entries;
 	uint64_t completion_signal_val = 1;
 	int i = 0;
+ 	uint64_t timeout_count = 0;
 
 	/* Advance the write index to reserve space in the buffer. */
 	iowrite64(wr_idx + 1, air_dev->queue_mgr.admin_queue.descriptor
@@ -137,7 +138,6 @@ static void vck5000_send_admin_queue_cmd_and_wait(struct amdair_device *air_dev,
 			   + pkt_id * AQL_PKT_SIZE
 			   + AQL_PKT_COMPLETION_SIGNAL_OFFSET);
 
- 	uint64_t timeout_count = 0;
 	while (completion_signal_val) {
 		completion_signal_val
 			= ioread64(air_dev->queue_mgr.admin_queue.ring_buf


### PR DESCRIPTION
Making it so when a process releases the driver, we release all of the queues used by the driver. Had to add the ability for `amdair_process_device` to track which queue IDs they have open. 